### PR TITLE
restrict bundler to 1.x during CI testing

### DIFF
--- a/ci/unit/Dockerfile
+++ b/ci/unit/Dockerfile
@@ -6,7 +6,7 @@ RUN cp /usr/share/logstash/logstash-core/versions-gem-copy.yml /usr/share/logsta
 ENV PATH="${PATH}:/usr/share/logstash/vendor/jruby/bin"
 ENV LOGSTASH_SOURCE=1
 ENV JARS_SKIP="true"
-RUN gem install bundler
+RUN gem install bundler -v '~> 1'
 WORKDIR /usr/share/plugins/this
 RUN bundle install
 COPY --chown=logstash:logstash . /usr/share/plugins/this


### PR DESCRIPTION
fixes https://travis-ci.org/logstash-plugins/logstash-filter-http/jobs/477274688#L521