### PR TITLE
[Doc] improvements and clarifications 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.0.1
+  - Fixed minor documentation issues [#9](https://github.com/logstash-plugins/logstash-filter-http/pull/9)
+
 ## 1.0.0
   - Minor documentation fixes
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -59,7 +59,7 @@ There are also multiple configuration options related to the HTTP connectivity:
 | <<plugins-{type}s-{plugin}-password>> |<<password,password>>|No
 | <<plugins-{type}s-{plugin}-pool_max>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-pool_max_per_route>> |<<number,number>>|No
-| <<plugins-{type}s-{plugin}-proxy>> |<<,>>|No
+| <<plugins-{type}s-{plugin}-proxy>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-request_timeout>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-retry_non_idempotent>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-socket_timeout>> |<<number,number>>|No
@@ -140,7 +140,8 @@ The URL to send the request to. The value can be fetched from event fields.
 
 The verb to be used for the HTTP request.
 
-&nbsp;
+[id="plugins-{type}s-{plugin}-connectivity-options"]
+==== HTTP Filter Connectivity Options
 
 [id="plugins-{type}s-{plugin}-automatic_retries"]
 ===== `automatic_retries`
@@ -335,11 +336,17 @@ If you set this you must also set the `password` option.
   * Value type is <<number,number>>
   * Default value is `200`
 
-How long to wait before checking if the connection is stale before executing a request on a connection using keepalive.
-# You may want to set this lower, possibly to 0 if you get connection errors regularly
-Quoting the Apache commons docs (this client is based Apache Commmons):
-'Defines period of inactivity in milliseconds after which persistent connections must be re-validated prior to being leased to the consumer. Non-positive value passed to this method disables connection validation. This check helps detect connections that have become stale (half-closed) while kept inactive in the pool.'
-See https://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/org/apache/http/impl/conn/PoolingHttpClientConnectionManager.html#setValidateAfterInactivity(int)[these docs for more info]
+How long to wait before checking for a stale connection to determine if a keepalive request is needed.
+Consider setting this value lower than the default, possibly to 0, if you get connection errors regularly.
+
+This client is based on Apache Commons. Here's how the
+https://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/org/apache/http/impl/conn/PoolingHttpClientConnectionManager.html#setValidateAfterInactivity(int)[Apache
+Commons documentation] describes this option: "Defines period of inactivity in
+milliseconds after which persistent connections must be re-validated prior to
+being leased to the consumer. Non-positive value passed to this method disables
+connection validation. This check helps detect connections that have become
+stale (half-closed) while kept inactive in the pool."
+
 
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]

--- a/logstash-filter-http.gemspec
+++ b/logstash-filter-http.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-filter-http'
-  s.version = '1.0.0'
+  s.version = '1.0.1'
   s.licenses = ['Apache License (2.0)']
   s.summary = 'This filter requests data from a RESTful Web Service.'
   s.description = 'This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install logstash-filter-http. This gem is not a stand-alone program'


### PR DESCRIPTION
This PR:

- fills in datatype for `proxy`
- adds a header to separate two sets of options
- cleans up formatting for `validate_after_inactivity`

To Do:
- When resolved, make updates to input-http_poller.