### PR TITLE
parameter_sprintfed removed

### DIFF
--- a/lib/logstash/filters/http.rb
+++ b/lib/logstash/filters/http.rb
@@ -51,7 +51,7 @@ class LogStash::Filters::Http < LogStash::Filters::Base
 
     options = { :headers => headers_sprintfed, :query => query_sprintfed, :body => body_sprintfed }
 
-    @logger.debug? && @logger.debug('processing request', :url => url_for_event, :headers => headers_sprintfed, :parameters => parameters_sprintfed)
+    @logger.debug? && @logger.debug('processing request', :url => url_for_event, :headers => headers_sprintfed)
     client_error = nil
 
     begin


### PR DESCRIPTION
This parameter is not present in the script, and causes and exception when attempting to run in debug mode.