### PR TITLE
Add forms in body_format and PUT in VALID_VERBS

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -86,10 +86,10 @@ The body of the HTTP request to be sent.
 [id="plugins-{type}s-{plugin}-body_format"]
 ===== `body_format`
 
-  * Value type can be either `"json"` or `"text"`
+  * Value type can be either `"json"`, `"form"`, or `"text"`
   * Default value is `"text"`
 
-If set to `"json"` the body will be serialized as JSON. Otherwise it is sent as is.
+If set to `"json"` the body will be serialized as JSON and the content-type header will be set to `application/json`. If set to `"form"`, the content-type header will be set to `application/x-www-form-urlencoded`. Otherwise it is sent as is with the content-type header set to `text/plain`.
 
 [id="plugins-{type}s-{plugin}-headers"]
 ===== `headers`
@@ -135,7 +135,7 @@ The URL to send the request to. The value can be fetched from event fields.
 [id="plugins-{type}s-{plugin}-verb"]
 ===== `verb`
 
-  * Value type can be either `"GET"`, `"HEAD"`, `"PATCH"`, `"DELETE"`, `"POST"`
+  * Value type can be either `"GET"`, `"HEAD"`, `"PATCH"`, `"DELETE"`, `"POST"`, `"PUT"`
   * Default value is `"GET"`
 
 The verb to be used for the HTTP request.

--- a/lib/logstash/filters/http.rb
+++ b/lib/logstash/filters/http.rb
@@ -12,7 +12,7 @@ class LogStash::Filters::Http < LogStash::Filters::Base
 
   config_name 'http'
 
-  VALID_VERBS = ['GET', 'HEAD', 'PATCH', 'DELETE', 'POST']
+  VALID_VERBS = ['GET', 'HEAD', 'PATCH', 'DELETE', 'POST', 'PUT']
 
   config :url, :validate => :string, :required => true
   config :verb, :validate => VALID_VERBS, :required => false, :default => 'GET'

--- a/lib/logstash/filters/http.rb
+++ b/lib/logstash/filters/http.rb
@@ -19,7 +19,7 @@ class LogStash::Filters::Http < LogStash::Filters::Base
   config :headers, :validate => :hash, :required => false, :default => {}
   config :query, :validate => :hash, :required => false, :default => {}
   config :body, :required => false
-  config :body_format, :validate => ['text', 'json'], :default => "text"
+  config :body_format, :validate => ['text', 'json', 'form'], :default => "text"
 
   config :target_body, :validate => :string, :default => "body"
   config :target_headers, :validate => :string, :default => "headers"
@@ -39,6 +39,8 @@ class LogStash::Filters::Http < LogStash::Filters::Base
     headers_sprintfed = sprintf_object(event, @headers)
     if body_format == "json"
       headers_sprintfed["content-type"] = "application/json"
+    elsif body_format == "form"
+      headers_sprintfed["content-type"] = "application/x-www-form-urlencoded"
     else
       headers_sprintfed["content-type"] = "text/plain"
     end


### PR DESCRIPTION
Adding support for a body_format value of 'form' to support content-type: application/x-www-form-urlencoded until the body_format config is removed in favor of content_type.