### PR TITLE
Add 'ignore_errors' boolean to also fetch responses with return codes != 200-299

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -52,7 +52,7 @@ There are also multiple configuration options related to the HTTP connectivity:
 | <<plugins-{type}s-{plugin}-connect_timeout>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-cookies>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-follow_redirects>> |<<boolean,boolean>>|No
-| <<plugins-{type}s-{plugin}-return_errors>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-ignore_errors>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-keepalive>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-keystore>> |a valid filesystem path|No
 | <<plugins-{type}s-{plugin}-keystore_password>> |<<password,password>>|No

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -52,6 +52,7 @@ There are also multiple configuration options related to the HTTP connectivity:
 | <<plugins-{type}s-{plugin}-connect_timeout>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-cookies>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-follow_redirects>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-return_errors>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-keepalive>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-keystore>> |a valid filesystem path|No
 | <<plugins-{type}s-{plugin}-keystore_password>> |<<password,password>>|No
@@ -201,6 +202,15 @@ across requests as a normal web browser would. Enabled by default
   * Default value is `true`
 
 Should redirects be followed? Defaults to `true`
+
+[id="plugins-{type}s-{plugin}-ignore_errors"]
+===== `ignore_errors`
+
+  * Value type is <<boolean,boolean>>
+  * Default value is `false`
+
+Set to `true` if you want to also process failed requests. Keep in mind that
+the filter will always succeed, unless there is an exception.
 
 [id="plugins-{type}s-{plugin}-keepalive"]
 ===== `keepalive`

--- a/spec/filters/http_spec.rb
+++ b/spec/filters/http_spec.rb
@@ -68,6 +68,26 @@ describe LogStash::Filters::Http do
       expect(event.get('tags')).to include('_httprequestfailure')
     end
   end
+  context 'when request returns 404 but ignores errors' do
+    before(:each) { subject.register }
+    let(:config) do
+      {
+        'url' => 'http://httpstat.us/404',
+        'target_body' => 'rest',
+        'ignore_errors' => true
+      }
+    end
+    let(:response) { [404, {}, "request failed"] }
+
+    before(:each) do
+      allow(subject).to receive(:request_http).and_return(response)
+      subject.filter(event)
+    end
+
+    it "fetches event and returns body" do
+      expect(event.get('rest')).to eq("request failed")
+    end
+  end
   describe "headers" do
     before(:each) { subject.register }
     let(:response) { [200, {}, "Bom dia"] }


### PR DESCRIPTION
This PR should add the possibility to just return the "errors" a REST call might have caused. This can be useful on permanent errors when you just want to know, what is the error and potentially use that information to be ingested later into elasticsearch.

Also added 'PUT' as an allowed verb.