### PR TITLE
added option 'ignorable_codes' to also return failed REST calls

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -52,7 +52,7 @@ There are also multiple configuration options related to the HTTP connectivity:
 | <<plugins-{type}s-{plugin}-connect_timeout>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-cookies>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-follow_redirects>> |<<boolean,boolean>>|No
-| <<plugins-{type}s-{plugin}-ignore_errors>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-ignorable_codes>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-keepalive>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-keystore>> |a valid filesystem path|No
 | <<plugins-{type}s-{plugin}-keystore_password>> |<<password,password>>|No
@@ -203,14 +203,14 @@ across requests as a normal web browser would. Enabled by default
 
 Should redirects be followed? Defaults to `true`
 
-[id="plugins-{type}s-{plugin}-ignore_errors"]
-===== `ignore_errors`
+[id="plugins-{type}s-{plugin}-ignorable_codes"]
+===== `ignorable_codes`
 
-  * Value type is <<boolean,boolean>>
-  * Default value is `false`
+  * Value type is <<number,number>>
+  * There is no default for this setting.
 
-Set to `true` if you want to also process failed requests. Keep in mind that
-the filter will always succeed, unless there is an exception.
+If you would like to consider some non-2xx codes to be successes
+enumerate them here. Responses returning these codes will be considered successes
 
 [id="plugins-{type}s-{plugin}-keepalive"]
 ===== `keepalive`

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -52,6 +52,7 @@ There are also multiple configuration options related to the HTTP connectivity:
 | <<plugins-{type}s-{plugin}-connect_timeout>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-cookies>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-follow_redirects>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-ignore_errors>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-keepalive>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-keystore>> |a valid filesystem path|No
 | <<plugins-{type}s-{plugin}-keystore_password>> |<<password,password>>|No
@@ -201,6 +202,15 @@ across requests as a normal web browser would. Enabled by default
   * Default value is `true`
 
 Should redirects be followed? Defaults to `true`
+
+[id="plugins-{type}s-{plugin}-ignore_errors"]
+===== `ignore_errors`
+
+  * Value type is <<boolean,boolean>>
+  * Default value is `false`
+
+Set to `true` if you want to also process failed requests. Keep in mind that
+the filter will always succeed, unless there is an exception.
 
 [id="plugins-{type}s-{plugin}-keepalive"]
 ===== `keepalive`

--- a/spec/filters/http_spec.rb
+++ b/spec/filters/http_spec.rb
@@ -68,6 +68,26 @@ describe LogStash::Filters::Http do
       expect(event.get('tags')).to include('_httprequestfailure')
     end
   end
+  context 'when request returns 404 but ignores errors' do
+    before(:each) { subject.register }
+    let(:config) do
+      {
+        'url' => 'http://httpstat.us/404',
+        'target_body' => 'rest',
+        'ignore_errors' => true
+      }
+    end
+    let(:response) { [404, {}, "request failed"] }
+
+    before(:each) do
+      allow(subject).to receive(:request_http).and_return(response)
+      subject.filter(event)
+    end
+
+    it "fetches event and returns body" do
+      expect(event.get('rest')).to eq("request failed")
+    end
+  end
   describe "headers" do
     before(:each) { subject.register }
     let(:response) { [200, {}, "Bom dia"] }

--- a/spec/filters/http_spec.rb
+++ b/spec/filters/http_spec.rb
@@ -217,7 +217,7 @@ describe LogStash::Filters::Http do
         "target_body" => "size"
       }
     end
-    ["GET", "HEAD", "POST", "DELETE"].each do |verb_string|
+    ["GET", "HEAD", "POST", "DELETE", "PUT"].each do |verb_string|
       let(:verb) { verb_string }
       context "when verb #{verb_string} is set" do
         before(:each) { subject.register }


### PR DESCRIPTION
Setting this option to `true` will return the response headers and response body also for failed REST calls. This means, unless there is an exception, setting `ignore_errors` to `true` will always succeed.

The idea behind is to also be able to fetch the results for failed HTTP requests, parse them and - maybe - use that data within elasticsearch.