### PR TITLE
Add support for PUT requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.0.3
+  - Add support for PUT requests [#34](https://github.com/logstash-plugins/logstash-filter-http/pull/34)
+
 ## 1.0.2
   - Fixed exception when using debug logging [#14](https://github.com/logstash-plugins/logstash-filter-http/pull/14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.3
+## 1.1.0
   - Add support for PUT requests [#34](https://github.com/logstash-plugins/logstash-filter-http/pull/34)
 
 ## 1.0.2

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -135,7 +135,7 @@ The URL to send the request to. The value can be fetched from event fields.
 [id="plugins-{type}s-{plugin}-verb"]
 ===== `verb`
 
-  * Value type can be either `"GET"`, `"HEAD"`, `"PATCH"`, `"DELETE"`, `"POST"`
+  * Value type can be either `"GET"`, `"HEAD"`, `"PATCH"`, `"DELETE"`, `"POST"`, `"PUT"`
   * Default value is `"GET"`
 
 The verb to be used for the HTTP request.

--- a/lib/logstash/filters/http.rb
+++ b/lib/logstash/filters/http.rb
@@ -12,7 +12,7 @@ class LogStash::Filters::Http < LogStash::Filters::Base
 
   config_name 'http'
 
-  VALID_VERBS = ['GET', 'HEAD', 'PATCH', 'DELETE', 'POST']
+  VALID_VERBS = ['GET', 'HEAD', 'PATCH', 'DELETE', 'POST', 'PUT']
 
   config :url, :validate => :string, :required => true
   config :verb, :validate => VALID_VERBS, :required => false, :default => 'GET'

--- a/logstash-filter-http.gemspec
+++ b/logstash-filter-http.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-filter-http'
-  s.version = '1.0.3'
+  s.version = '1.1.0'
   s.licenses = ['Apache License (2.0)']
   s.summary = 'This filter requests data from a RESTful Web Service.'
   s.description = 'This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install logstash-filter-http. This gem is not a stand-alone program'

--- a/logstash-filter-http.gemspec
+++ b/logstash-filter-http.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-filter-http'
-  s.version = '1.0.2'
+  s.version = '1.0.3'
   s.licenses = ['Apache License (2.0)']
   s.summary = 'This filter requests data from a RESTful Web Service.'
   s.description = 'This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install logstash-filter-http. This gem is not a stand-alone program'

--- a/spec/filters/http_spec.rb
+++ b/spec/filters/http_spec.rb
@@ -197,7 +197,7 @@ describe LogStash::Filters::Http do
         "target_body" => "size"
       }
     end
-    ["GET", "HEAD", "POST", "DELETE"].each do |verb_string|
+    ["GET", "HEAD", "POST", "DELETE", "PATCH", "PUT"].each do |verb_string|
       let(:verb) { verb_string }
       context "when verb #{verb_string} is set" do
         before(:each) { subject.register }


### PR DESCRIPTION
## What does this PR do?

This PR adds support for the PUT HTTP request method. 

## Why is it important/What is the impact to the user?

Supporting PUT is important as some APIs (for example the Elasticsearch API) don't support POST/PUT interchangeably.

I noticed that there were multiple other PRs that attempted to add PUT functionality https://github.com/logstash-plugins/logstash-filter-http/pull/32 and https://github.com/logstash-plugins/logstash-filter-http/pull/28, but they haven't been merged due to reasons unrelated to this functionality.  

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files (and/or docker env variables)
- [x] I have added tests that prove my fix is effective or that my feature works

## Related issues
- https://github.com/logstash-plugins/logstash-filter-http/pull/32
- https://github.com/logstash-plugins/logstash-filter-http/pull/28