### PR TITLE
Feat: improve ECS compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.2.0
+  - Feat: improve ECS compatibility [#35](https://github.com/logstash-plugins/logstash-filter-http/pull/35)
+
 ## 1.1.0
   - Add support for PUT requests [#34](https://github.com/logstash-plugins/logstash-filter-http/pull/34)
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -22,6 +22,14 @@ include::{include_path}/plugin_header.asciidoc[]
 
 The HTTP filter provides integration with external web services/REST APIs.
 
+[id="plugins-{type}s-{plugin}-ecs"]
+==== Compatibility with the Elastic Common Schema (ECS)
+
+The plugin includes sensible defaults that change based on <<plugins-{type}s-{plugin}-ecs_compatibility,ECS compatibility mode>>.
+When targeting an ECS version, headers are set as `@metadata` and the response body is set according to ECS.
+See <<plugins-{type}s-{plugin}-target_body>>, and <<plugins-{type}s-{plugin}-target_headers>>.
+
+
 [id="plugins-{type}s-{plugin}-options"]
 ==== HTTP Filter Configuration Options
 
@@ -32,6 +40,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 |Setting |Input type|Required
 | <<plugins-{type}s-{plugin}-body>> | String, Array or Hash |No
 | <<plugins-{type}s-{plugin}-body_format>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-ecs_compatibility>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-headers>> |<<hash,hash>>|No
 | <<plugins-{type}s-{plugin}-query>> |<<hash,hash>>|No
 | <<plugins-{type}s-{plugin}-target_body>> |<<string,string>>|No
@@ -91,6 +100,22 @@ The body of the HTTP request to be sent.
 
 If set to `"json"` the body will be serialized as JSON. Otherwise it is sent as is.
 
+[id="plugins-{type}s-{plugin}-ecs_compatibility"]
+===== `ecs_compatibility`
+
+  * Value type is <<string,string>>
+  * Supported values are:
+    ** `disabled`: does not use ECS-compatible field names (for example, response headers target `headers` field by default)
+    ** `v1`, `v8`: avoids field names that might conflict with Elastic Common Schema (for example, headers are added as metadata)
+  * Default value depends on which version of Logstash is running:
+    ** When Logstash provides a `pipeline.ecs_compatibility` setting, its value is used as the default
+    ** Otherwise, the default value is `disabled`.
+
+Controls this plugin's compatibility with the {ecs-ref}[Elastic Common Schema (ECS)].
+The value of this setting affects the _default_ value of <<plugins-{type}s-{plugin}-target_body>> and
+<<plugins-{type}s-{plugin}-target_headers>>.
+
+
 [id="plugins-{type}s-{plugin}-headers"]
 ===== `headers`
 
@@ -113,16 +138,21 @@ Define the query string parameters (key-value pairs) to be sent in the HTTP requ
 
   * Value type is <<hash,hash>>
   * There is no default value
+  * Default value depends on whether <<plugins-{type}s-{plugin}-ecs_compatibility>> is enabled:
+    ** ECS Compatibility disabled: `"[body]"
+    ** ECS Compatibility enabled: `"[http][response][body][content]"
 
-Define the target field for placing the body of the HTTP response. If this setting is omitted, the data will be stored in the "body" field.
+Define the target field for placing the body of the HTTP response.
 
 [id="plugins-{type}s-{plugin}-target_headers"]
 ===== `target_headers`
 
   * Value type is <<hash,hash>>
-  * There is no default value
+  * Default value depends on whether <<plugins-{type}s-{plugin}-ecs_compatibility>> is enabled:
+    ** ECS Compatibility disabled: `"[headers]"`
+    ** ECS Compatibility enabled: `"[@metadata][filter][http][response][headers]"`
 
-Define the target field for placing the headers of the HTTP response. If this setting is omitted, the data will be stored in the "headers" field.
+Define the target field for placing the headers of the HTTP response.
 
 [id="plugins-{type}s-{plugin}-url"]
 ===== `url`

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -26,7 +26,7 @@ The HTTP filter provides integration with external web services/REST APIs.
 ==== Compatibility with the Elastic Common Schema (ECS)
 
 The plugin includes sensible defaults that change based on <<plugins-{type}s-{plugin}-ecs_compatibility,ECS compatibility mode>>.
-When targeting an ECS version, headers are set as `@metadata` and the response body is set according to ECS.
+When targeting an ECS version, headers are set as `@metadata` and the `target_body` is a required option.
 See <<plugins-{type}s-{plugin}-target_body>>, and <<plugins-{type}s-{plugin}-target_headers>>.
 
 
@@ -137,10 +137,9 @@ Define the query string parameters (key-value pairs) to be sent in the HTTP requ
 ===== `target_body`
 
   * Value type is <<hash,hash>>
-  * There is no default value
   * Default value depends on whether <<plugins-{type}s-{plugin}-ecs_compatibility>> is enabled:
     ** ECS Compatibility disabled: `"[body]"
-    ** ECS Compatibility enabled: `"[http][response][body][content]"
+    ** ECS Compatibility enabled: no default value, needs to be specified explicitly
 
 Define the target field for placing the body of the HTTP response.
 

--- a/lib/logstash/filters/http.rb
+++ b/lib/logstash/filters/http.rb
@@ -29,7 +29,8 @@ class LogStash::Filters::Http < LogStash::Filters::Base
   config :body, :required => false
   config :body_format, :validate => ['text', 'json'], :default => "text"
 
-  config :target_body, :validate => :field_reference, :default => "body"
+  # default [body] (legacy) or [http][request][body][content] in ECS mode
+  config :target_body, :validate => :field_reference
   # default [headers] (legacy) or [@metadata][filter][http][request][headers] in ECS mode
   config :target_headers, :validate => :field_reference
 
@@ -42,6 +43,7 @@ class LogStash::Filters::Http < LogStash::Filters::Base
     # nothing to see here
     @verb = verb.downcase
 
+    @target_body ||= ecs_select[disabled: '[body]', v1: '[http][request][body][content]']
     @target_headers ||= ecs_select[disabled: '[headers]', v1: '[@metadata][filter][http][request][headers]']
   end
 

--- a/lib/logstash/filters/http.rb
+++ b/lib/logstash/filters/http.rb
@@ -29,9 +29,9 @@ class LogStash::Filters::Http < LogStash::Filters::Base
   config :body, :required => false
   config :body_format, :validate => ['text', 'json'], :default => "text"
 
-  # default [body] (legacy) or [http][request][body][content] in ECS mode
+  # default [body] (legacy) or [http][response][body][content] in ECS mode
   config :target_body, :validate => :field_reference
-  # default [headers] (legacy) or [@metadata][filter][http][request][headers] in ECS mode
+  # default [headers] (legacy) or [@metadata][filter][http][response][headers] in ECS mode
   config :target_headers, :validate => :field_reference
 
   # Append values to the `tags` field when there has been no
@@ -43,8 +43,8 @@ class LogStash::Filters::Http < LogStash::Filters::Base
     # nothing to see here
     @verb = verb.downcase
 
-    @target_body ||= ecs_select[disabled: '[body]', v1: '[http][request][body][content]']
-    @target_headers ||= ecs_select[disabled: '[headers]', v1: '[@metadata][filter][http][request][headers]']
+    @target_body ||= ecs_select[disabled: '[body]', v1: '[http][response][body][content]']
+    @target_headers ||= ecs_select[disabled: '[headers]', v1: '[@metadata][filter][http][response][headers]']
   end
 
   def filter(event)

--- a/logstash-filter-http.gemspec
+++ b/logstash-filter-http.gemspec
@@ -27,7 +27,9 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency 'logstash-core-plugin-api', '>= 1.60', '<= 2.99'
+  s.add_runtime_dependency 'logstash-mixin-ecs_compatibility_support', '~>1.2'
   s.add_runtime_dependency 'logstash-mixin-http_client', '>= 5.0.0', '< 9.0.0'
+  s.add_runtime_dependency 'logstash-mixin-validator_support', '~> 1.0'
 
   s.add_development_dependency 'logstash-devutils'
 end

--- a/logstash-filter-http.gemspec
+++ b/logstash-filter-http.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-filter-http'
-  s.version = '1.1.0'
+  s.version = '1.2.0'
   s.licenses = ['Apache License (2.0)']
   s.summary = 'This filter requests data from a RESTful Web Service.'
   s.description = 'This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install logstash-filter-http. This gem is not a stand-alone program'

--- a/spec/filters/http_spec.rb
+++ b/spec/filters/http_spec.rb
@@ -16,7 +16,7 @@ describe LogStash::Filters::Http do
 
     let(:config) { { "url" => url, "ecs_compatibility" => ecs_compatibility } }
 
-    ecs_compatibility_matrix(:disabled, :v1) do |ecs_select|
+    ecs_compatibility_matrix(:disabled, :v1, :v8) do |ecs_select|
 
       it "has a default body_target (in legacy mode)" do
         subject.register
@@ -45,7 +45,7 @@ describe LogStash::Filters::Http do
       subject.filter(event)
     end
 
-    ecs_compatibility_matrix(:disabled, :v1) do
+    ecs_compatibility_matrix(:disabled, :v1, :v8) do
 
       let(:config) { super().merge "ecs_compatibility" => ecs_compatibility, 'target_body' => 'gw-response' }
 
@@ -179,12 +179,8 @@ describe LogStash::Filters::Http do
     let(:response) { [200, {}, "Bom dia"] }
     context "when set" do
       let(:query) { { "color" => "green" } }
-      let(:config) do
-        {
-          "url" => "http://stringsize.com/%{message}",
-          "query" => query
-        }
-      end
+      let(:config) { super().merge "query" => query }
+
       it "are included in the request" do
         expect(subject).to receive(:request_http).with(anything, anything, include(:query => query)).and_return(response)
         subject.filter(event)
@@ -194,21 +190,11 @@ describe LogStash::Filters::Http do
   describe "request body" do
     before(:each) { subject.register }
     let(:response) { [200, {}, "Bom dia"] }
-    let(:config) do
-      {
-        "url" => "http://stringsize.com",
-        "body" => body
-      }
-    end
+    let(:url) { "http://stringsize.com" }
+    let(:config) { super().merge "body" => body }
 
     describe "format" do
-      let(:config) do
-        {
-          "url" => "http://stringsize.com",
-          "body_format" => body_format,
-          "body" => body
-        }
-      end
+      let(:config) { super().merge "body_format" => body_format, "body" => body }
 
       context "when is json" do
         let(:body_format) { "json" }
@@ -275,12 +261,8 @@ describe LogStash::Filters::Http do
   end
   describe "verb" do
     let(:response) { [200, {}, "Bom dia"] }
-    let(:config) do
-      {
-        "verb" => verb,
-        "url" => "http://stringsize.com",
-      }
-    end
+    let(:config) { super().merge "verb" => verb }
+
     ["GET", "HEAD", "POST", "DELETE", "PATCH", "PUT"].each do |verb_string|
       let(:verb) { verb_string }
       context "when verb #{verb_string} is set" do

--- a/spec/filters/http_spec.rb
+++ b/spec/filters/http_spec.rb
@@ -31,7 +31,7 @@ describe LogStash::Filters::Http do
           if ecs_select.active_mode == :disabled
             expect(event.get('body')).to eq("Bom dia")
           else
-            expect(event.get('[http][request][body][content]')).to eql 'Bom dia'
+            expect(event.get('[http][response][body][content]')).to eql 'Bom dia'
           end
         end
 
@@ -49,7 +49,7 @@ describe LogStash::Filters::Http do
               expect(event.include?('[body]')).to be false
 
               # TODO: this is going to cause issues with an ECS template!?
-              expect(event.get('[http][request][body][content][id]')).to eq(10)
+              expect(event.get('[http][response][body][content][id]')).to eq(10)
             end
           end
 
@@ -133,22 +133,22 @@ describe LogStash::Filters::Http do
           expect(event.get('headers')).to include "X-Backend-Server" => "logstash.elastic.co"
         else
           expect(event.include?('headers')).to be false
-          expect(event.get('[@metadata][filter][http][request][headers]')).to include "Server" => "Apache"
-          expect(event.get('[@metadata][filter][http][request][headers]')).to include "X-Backend-Server" => "logstash.elastic.co"
+          expect(event.get('[@metadata][filter][http][response][headers]')).to include "Server" => "Apache"
+          expect(event.get('[@metadata][filter][http][response][headers]')).to include "X-Backend-Server" => "logstash.elastic.co"
         end
       end
 
       context 'with a headers target' do
 
-        let(:config) { super().merge "target_headers" => '[req][headers]' }
+        let(:config) { super().merge "target_headers" => '[res][headers]' }
 
         it "sets response headers in the event" do
           expect(subject).to receive(:request_http).with(anything, config['url'], anything).and_return(response)
 
           subject.filter(event)
 
-          expect(event.get('[req][headers]')).to include "Server" => "Apache"
-          expect(event.get('[req][headers]').keys).to include "Last-Modified"
+          expect(event.get('[res][headers]')).to include "Server" => "Apache"
+          expect(event.get('[res][headers]').keys).to include "Last-Modified"
         end
 
       end


### PR DESCRIPTION
Plugin uses `target_body => '[body]'` and `target_headers => '[headers]`' in legacy mode, these were updated to:
- `target_body` ~~default to `[http][request][body][content]` in ECS mode~~ required to be set in ECS mode
- `target_headers` default to `[@metadata][filter][http][request][headers]` in ECS mode


~~However there's one TODO left - suppose the returned response body is `{ "foo": "bar" }` with the `application/json` header.
The plugin detects the JSON format and parses the body before setting the content into `target_body` and thus ends up with:
`event.get '[http][request][body][content][foo]'` => `"bar"`~~