### PR TITLE
Fix: do not set content-type if provided by user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.2.1
+  - Fix: do not set content-type if provided by user [#36](https://github.com/logstash-plugins/logstash-filter-http/pull/36)
+
 ## 1.2.0
   - Feat: improve ECS compatibility [#35](https://github.com/logstash-plugins/logstash-filter-http/pull/35)
 

--- a/lib/logstash/filters/http.rb
+++ b/lib/logstash/filters/http.rb
@@ -59,10 +59,8 @@ class LogStash::Filters::Http < LogStash::Filters::Base
   def filter(event)
     url_for_event = event.sprintf(@url)
     headers_sprintfed = sprintf_object(event, @headers)
-    if body_format == "json"
-      headers_sprintfed["content-type"] = "application/json"
-    else
-      headers_sprintfed["content-type"] = "text/plain"
+    if !headers_sprintfed.key?('content-type') && !headers_sprintfed.key?('Content-Type')
+      headers_sprintfed['content-type'] = @body_format == "json" ? "application/json" : "text/plain"
     end
     query_sprintfed = sprintf_object(event, @query)
     body_sprintfed = sprintf_object(event, @body)

--- a/logstash-filter-http.gemspec
+++ b/logstash-filter-http.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-filter-http'
-  s.version = '1.2.0'
+  s.version = '1.2.1'
   s.licenses = ['Apache License (2.0)']
   s.summary = 'This filter requests data from a RESTful Web Service.'
   s.description = 'This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install logstash-filter-http. This gem is not a stand-alone program'

--- a/spec/filters/http_spec.rb
+++ b/spec/filters/http_spec.rb
@@ -209,12 +209,14 @@ describe LogStash::Filters::Http do
           end.and_return(response)
           subject.filter(event)
         end
+
         it "sets content-type to application/json" do
           expect(subject).to receive(:request_http) do |verb, url, options|
             expect(options).to include(:headers => { "content-type" => "application/json"})
           end.and_return(response)
           subject.filter(event)
         end
+
       end
       context "when is text" do
         let(:body_format) { "text" }
@@ -226,12 +228,29 @@ describe LogStash::Filters::Http do
           end.and_return(response)
           subject.filter(event)
         end
+
         it "sets content-type to text/plain" do
           expect(subject).to receive(:request_http) do |verb, url, options|
             expect(options).to include(:headers => { "content-type" => "text/plain"})
           end.and_return(response)
           subject.filter(event)
         end
+
+        context 'content-type header present' do
+
+          let(:config) { super().merge 'headers' => { 'X-UA' => 'FOO', 'Content-Type' => 'application/x-www-form-urlencoded' } }
+
+          it "respects set header and does not add another" do
+            expect(subject).to receive(:request_http) do |verb, url, options|
+              headers = options[:headers]
+              expect(headers).to include("Content-Type" => "application/x-www-form-urlencoded")
+              expect(headers).to_not include("content-type")
+            end.and_return(response)
+            subject.filter(event)
+          end
+
+        end
+
       end
     end
     context "when using field references" do


### PR DESCRIPTION
When user sets:

```ruby
filter {
  http {  
    headers => { "Content-Type" => "application/xml" }
  }
}
```

the filter should not add another `content-type` => `text/plain` header