### PR TITLE
Feat: support ssl_verification_mode option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.3.0
+  - Feat: support ssl_verification_mode option [#37](https://github.com/logstash-plugins/logstash-filter-http/pull/37)
+
 ## 1.2.1
   - Fix: do not set content-type if provided by user [#36](https://github.com/logstash-plugins/logstash-filter-http/pull/36)
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -72,6 +72,7 @@ There are also multiple configuration options related to the HTTP connectivity:
 | <<plugins-{type}s-{plugin}-request_timeout>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-retry_non_idempotent>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-socket_timeout>> |<<number,number>>|No
+| <<plugins-{type}s-{plugin}-ssl_verification_mode>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-truststore>> |a valid filesystem path|No
 | <<plugins-{type}s-{plugin}-truststore_password>> |<<password,password>>|No
 | <<plugins-{type}s-{plugin}-truststore_type>> |<<string,string>>|No
@@ -324,6 +325,22 @@ If `automatic_retries` is enabled this will cause non-idempotent HTTP verbs (suc
   * Default value is `10`
 
 Timeout (in seconds) to wait for data on the socket. Default is `10s`
+
+[id="plugins-{type}s-{plugin}-ssl_verification_mode"]
+===== `ssl_verification_mode`
+
+* Value type is <<string,string>>
+* Supported values are: `full`, `none`
+* Default value is `full`
+
+Controls the verification of server certificates.
+The `full` option verifies that the provided certificate is signed by a trusted authority (CA)
+and also that the server’s hostname (or IP address) matches the names identified within the certificate.
+
+The `none` setting performs no verification of the server’s certificate.
+This mode disables many of the security benefits of SSL/TLS and should only be used after cautious consideration.
+It is primarily intended as a temporary diagnostic mechanism when attempting to resolve TLS errors.
+Using `none`  in production environments is strongly discouraged.
 
 [id="plugins-{type}s-{plugin}-truststore"]
 ===== `truststore`

--- a/logstash-filter-http.gemspec
+++ b/logstash-filter-http.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-filter-http'
-  s.version = '1.2.1'
+  s.version = '1.3.0'
   s.licenses = ['Apache License (2.0)']
   s.summary = 'This filter requests data from a RESTful Web Service.'
   s.description = 'This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install logstash-filter-http. This gem is not a stand-alone program'
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   # Gem dependencies
   s.add_runtime_dependency 'logstash-core-plugin-api', '>= 1.60', '<= 2.99'
   s.add_runtime_dependency 'logstash-mixin-ecs_compatibility_support', '~>1.2'
-  s.add_runtime_dependency 'logstash-mixin-http_client', '>= 5.0.0', '< 9.0.0'
+  s.add_runtime_dependency "logstash-mixin-http_client", ">= 7.1.0", '< 9.0.0'
   s.add_runtime_dependency 'logstash-mixin-validator_support', '~> 1.0'
 
   s.add_development_dependency 'logstash-devutils'


### PR DESCRIPTION
the feature itself comes from the mixin: https://github.com/logstash-plugins/logstash-mixin-http_client/pull/39