### PR TITLE
include http status code in metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.5.0
+  - Feat: add http response status code to metadata
+
 ## 1.4.1
   - Fix: don't process response body for HEAD requests [#40](https://github.com/logstash-plugins/logstash-filter-http/pull/40)
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -45,6 +45,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-query>> |<<hash,hash>>|No
 | <<plugins-{type}s-{plugin}-target_body>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-target_headers>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-target_status>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-url>> |<<string,string>>|Yes
 | <<plugins-{type}s-{plugin}-verb>> |<<string,string>>|No
 |=======================================================================
@@ -154,6 +155,14 @@ Define the target field for placing the body of the HTTP response.
     ** ECS Compatibility enabled: `"[@metadata][filter][http][response][headers]"`
 
 Define the target field for placing the headers of the HTTP response.
+
+[id="plugins-{type}s-{plugin}-target_status"]
+===== `target_status`
+
+  * Value type is <<string,string>>
+  * Default value `"[@metadata][filter][http][response][status_code]"`
+
+Define the target field for placing the status code of the HTTP response.
 
 [id="plugins-{type}s-{plugin}-url"]
 ===== `url`

--- a/logstash-filter-http.gemspec
+++ b/logstash-filter-http.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-filter-http'
-  s.version = '1.4.1'
+  s.version = '1.5.0'
   s.licenses = ['Apache License (2.0)']
   s.summary = 'This filter requests data from a RESTful Web Service.'
   s.description = 'This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install logstash-filter-http. This gem is not a stand-alone program'


### PR DESCRIPTION
## Release notes

The HTTP status code for each request is now included in the response metadata.

## What does this PR do?

Adds HTTP status code of response

## Why is it important/What is the impact to the user?

Adds HTTP status code of response, so that a pipeline can differentiate between the semantics of different error status codes. For example, in some contexts a `404` (`Not Found`) is substantially different than a `400` (`Bad Request`), and it may be helpful for downstream plugins in a pipeline to handle the two cases separately.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files (and/or docker env variables)
- [x] I have added tests that prove my fix is effective or that my feature works

## Related issues

 - Resolves: https://github.com/elastic/logstash/issues/14368
