### PR TITLE
Resolve the content type from the list/array of content-types.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
+## 1.4.2
+  - Fix: resolve content type when a content-type header contains an array [#46](https://github.com/logstash-plugins/logstash-filter-http/pull/46)
+
 ## 1.4.1
-  - Fix: don't process response body for HEAD requests [#40](https://github.com/logstash-plugins/logstash-filter-http/pull/40)
+  - Fix: don't process response body for HEAD requests [#41](https://github.com/logstash-plugins/logstash-filter-http/pull/41)
 
 ## 1.4.0
   - Feat: added ssl_supported_protocols option [#38](https://github.com/logstash-plugins/logstash-filter-http/pull/38)

--- a/lib/logstash/filters/http.rb
+++ b/lib/logstash/filters/http.rb
@@ -136,8 +136,7 @@ EOF
     event.set(@target_headers, headers)
     return if @verb == 'head' # Since HEAD requests will not contain body, we need to set only header
 
-    content_type = resolve_content_type(headers)
-    if content_type == "application/json"
+    if headers_has_json_content_type?(headers)
       begin
         parsed = LogStash::Json.load(body)
         event.set(@target_body, parsed)
@@ -157,10 +156,12 @@ EOF
   ##
   # @param headers [String] or [Array]
   # @return resolved content-type
-  def resolve_content_type(headers)
+  def headers_has_json_content_type?(headers)
     # content-type might be an array or string with ; separated
-    content_types = headers.fetch("content-type", "")
-    content_types.kind_of?(Array) ? content_types.first : content_types.split(";").first
+    [ headers.fetch("content-type", "") ]
+             .map {|i| i }
+             .flatten
+             .include?("application/json")
   end
 
 end # class LogStash::Filters::Rest

--- a/lib/logstash/filters/http.rb
+++ b/lib/logstash/filters/http.rb
@@ -158,10 +158,9 @@ EOF
   # @return resolved content-type
   def headers_has_json_content_type?(headers)
     # content-type might be an array or string with ; separated
-    [ headers.fetch("content-type", "") ]
-             .map {|i| i }
-             .flatten
-             .include?("application/json")
+    headers = headers.fetch("content-type", "")
+    headers = headers.kind_of?(Array) ? headers : headers.split(';')
+    headers.map(&:strip).include?("application/json")
   end
 
 end # class LogStash::Filters::Rest

--- a/logstash-filter-http.gemspec
+++ b/logstash-filter-http.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-filter-http'
-  s.version = '1.4.1'
+  s.version = '1.4.2'
   s.licenses = ['Apache License (2.0)']
   s.summary = 'This filter requests data from a RESTful Web Service.'
   s.description = 'This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install logstash-filter-http. This gem is not a stand-alone program'


### PR DESCRIPTION

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
[rn:skip] 

## What does this PR do?
Fixes the crash when plugin receives the `Content-Type` header as an `Array`. This change introduces a resolution of content type which supports: `array`, `string` and empty `string`.

## Why is it important/What is the impact to the user?
Some applications (example [apigateway-openlogging-elk](https://github.com/Axway-API-Management-Plus/apigateway-openlogging-elk)) is using a server which responses list of `Content-Type` media types.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files (and/or docker env variables)
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally
- Clone the change
- Use following config
```
filter {
    http {
        url => "http://localhost:8081"
        target_body => "body"
        target_headers => "headers"
    }
}
```
- Run a server which returns Content-Type array
```
var http = require("http");

http.createServer(function (request, response) {
   response.writeHead(200, {'Content-Type': ['text/plain', 'logstash/custom-type']} );
   response.end('Hello World\n');
}).listen(8081);

console.log('Server running at http://127.0.0.1:8081/');
```

## Related issues
- Closes #45 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
