### PR TITLE
Don't process response when the body is empty.

### DIFF
--- a/lib/logstash/filters/http.rb
+++ b/lib/logstash/filters/http.rb
@@ -136,6 +136,8 @@ EOF
     event.set(@target_headers, headers)
     return if @verb == 'head' # Since HEAD requests will not contain body, we need to set only header
 
+    return if body.nil? #Return on empty bodys (e.g. 204 response)
+
     if headers_has_json_content_type?(headers)
       begin
         parsed = LogStash::Json.load(body)

--- a/spec/filters/http_spec.rb
+++ b/spec/filters/http_spec.rb
@@ -61,6 +61,14 @@ describe LogStash::Filters::Http do
         end
       end
 
+      context "when there is no body" do
+        let(:response) { [204, {}, nil] }
+
+        it "doesn't write a body to the event" do
+          expect(event.get('[gw-response]')).to be_nil
+        end
+      end
+
       context 'with body target' do
 
         let(:config) { super().merge "target_body" => '[rest]' }


### PR DESCRIPTION
- bug



## What does this PR do?
Return from `process_response` if the body is empty.
Don't process response when the body is empty.


## Why is it important/What is the impact to the user?
This PR fixes the issue that would cause the filter to throw when receiving an empty body in the response. At the moment, when an server returns an empty body, a common example being the result of a DELETE request, the pipeline crashes. When the body is empty the `process_response` function should return immediately.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [~] I have made corresponding changes to the documentation
- [~] I have made corresponding change to the default configuration files (and/or docker env variables)
- [~] I have added tests that prove my fix is effective or that my feature works

## Related issues
Closes #25 

