### PR TITLE
Capture response details for non-2xx HTTP status codes

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -27,7 +27,7 @@ The HTTP filter provides integration with external web services/REST APIs.
 
 The plugin includes sensible defaults that change based on <<plugins-{type}s-{plugin}-ecs_compatibility,ECS compatibility mode>>.
 When targeting an ECS version, headers are set as `@metadata` and the `target_body` is a required option.
-See <<plugins-{type}s-{plugin}-target_body>>, and <<plugins-{type}s-{plugin}-target_headers>>.
+See <<plugins-{type}s-{plugin}-target_body>>, <<plugins-{type}s-{plugin}-target_headers>>, and <<plugins-{type}s-{plugin}-target_status_code>>.
 
 
 [id="plugins-{type}s-{plugin}-options"]
@@ -45,9 +45,12 @@ Please check out <<plugins-{type}s-{plugin}-obsolete-options>> for details.
 | <<plugins-{type}s-{plugin}-body_format>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-ecs_compatibility>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-headers>> |<<hash,hash>>|No
+| <<plugins-{type}s-{plugin}-include_body_on_failure>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-include_status_code>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-query>> |<<hash,hash>>|No
 | <<plugins-{type}s-{plugin}-target_body>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-target_headers>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-target_status_code>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-url>> |<<string,string>>|Yes
 | <<plugins-{type}s-{plugin}-verb>> |<<string,string>>|No
 |=======================================================================
@@ -129,8 +132,8 @@ If set to `"json"` and the <<plugins-{type}s-{plugin}-body>> is a type of <<arra
     ** Otherwise, the default value is `disabled`.
 
 Controls this plugin's compatibility with the {ecs-ref}[Elastic Common Schema (ECS)].
-The value of this setting affects the _default_ value of <<plugins-{type}s-{plugin}-target_body>> and
-<<plugins-{type}s-{plugin}-target_headers>>.
+The value of this setting affects the _default_ value of <<plugins-{type}s-{plugin}-target_body>>,
+<<plugins-{type}s-{plugin}-target_headers>>, and <<plugins-{type}s-{plugin}-target_status_code>>.
 
 
 [id="plugins-{type}s-{plugin}-headers"]
@@ -141,6 +144,53 @@ The value of this setting affects the _default_ value of <<plugins-{type}s-{plug
 
 The HTTP headers to be sent in the request. Both the names of the headers and their
 values can reference values from event fields.
+
+[id="plugins-{type}s-{plugin}-include_body_on_failure"]
+===== `include_body_on_failure`
+
+  * Value type is <<boolean,boolean>>
+  * Default value is `true`
+
+When enabled, the plugin will capture and store the response body even for non-2xx HTTP status codes.
+This is useful for debugging and error handling, as error responses often contain valuable information
+about what went wrong.
+
+Example usage:
+```
+http {
+  url => "https://api.example.com/endpoint"
+  include_body_on_failure => true
+  target_body => "[http_response][body]"
+}
+```
+
+When a request fails with a 4xx or 5xx status code, the response body will still be available in the
+`target_body` field. For connection errors (timeouts, connection refused, etc.), a structured error
+message will be stored instead.
+
+[id="plugins-{type}s-{plugin}-include_status_code"]
+===== `include_status_code`
+
+  * Value type is <<boolean,boolean>>
+  * Default value is `true`
+
+When enabled, the plugin will capture and store the HTTP status code for all responses, including
+successful, failed, and error responses. This allows for better monitoring and conditional processing
+in subsequent filters.
+
+Example usage:
+```
+http {
+  url => "https://api.example.com/endpoint"
+  include_status_code => true
+  target_status_code => "[@metadata][http_status]"
+}
+```
+
+Status codes are stored as follows:
+* **2xx responses**: The actual status code (e.g., 200, 201, 204)
+* **Non-2xx responses**: The actual status code (e.g., 400, 404, 500, 503)
+* **Connection errors**: Status code is set to `0` to indicate a connection/client error
 
 [id="plugins-{type}s-{plugin}-query"]
 ===== `query`
@@ -153,22 +203,59 @@ Define the query string parameters (key-value pairs) to be sent in the HTTP requ
 [id="plugins-{type}s-{plugin}-target_body"]
 ===== `target_body`
 
-  * Value type is <<hash,hash>>
+  * Value type is <<string,string>>
   * Default value depends on whether <<plugins-{type}s-{plugin}-ecs_compatibility>> is enabled:
-    ** ECS Compatibility disabled: `"[body]"
+    ** ECS Compatibility disabled: `"[body]"`
     ** ECS Compatibility enabled: no default value, needs to be specified explicitly
 
 Define the target field for placing the body of the HTTP response.
 
+When <<plugins-{type}s-{plugin}-include_body_on_failure>> is enabled (default), this field will contain:
+* **For successful responses (2xx)**: The response body from the server
+* **For error responses (4xx, 5xx)**: The error response body from the server (if available)
+* **For connection errors**: A structured error message with error details
+
 [id="plugins-{type}s-{plugin}-target_headers"]
 ===== `target_headers`
 
-  * Value type is <<hash,hash>>
+  * Value type is <<string,string>>
   * Default value depends on whether <<plugins-{type}s-{plugin}-ecs_compatibility>> is enabled:
     ** ECS Compatibility disabled: `"[headers]"`
     ** ECS Compatibility enabled: `"[@metadata][filter][http][response][headers]"`
 
 Define the target field for placing the headers of the HTTP response.
+
+[id="plugins-{type}s-{plugin}-target_status_code"]
+===== `target_status_code`
+
+  * Value type is <<string,string>>
+  * Default value depends on whether <<plugins-{type}s-{plugin}-ecs_compatibility>> is enabled:
+    ** ECS Compatibility disabled: `"[@metadata][http_status_code]"`
+    ** ECS Compatibility enabled: `"[@metadata][filter][http][response][status_code]"`
+
+Define the target field for storing the HTTP status code of the response.
+
+This field is populated when <<plugins-{type}s-{plugin}-include_status_code>> is enabled (default).
+The status code can be used for conditional processing, monitoring, and debugging.
+
+Example usage:
+```
+filter {
+  http {
+    url => "https://api.example.com/endpoint"
+    target_status_code => "[http][status]"
+    target_body => "[http][response]"
+  }
+  
+  # Use the status code for conditional processing
+  if [http][status] and [http][status] >= 400 {
+    mutate {
+      add_tag => [ "http_error" ]
+      add_field => { "error_status" => "%{[http][status]}" }
+    }
+  }
+}
+```
 
 [id="plugins-{type}s-{plugin}-url"]
 ===== `url`
@@ -415,9 +502,9 @@ The format of the truststore file. It must be either `jks` or `pkcs12`.
 
 Controls the verification of server certificates.
 The `full` option verifies that the provided certificate is signed by a trusted authority (CA)
-and also that the server’s hostname (or IP address) matches the names identified within the certificate.
+and also that the server's hostname (or IP address) matches the names identified within the certificate.
 
-The `none` setting performs no verification of the server’s certificate.
+The `none` setting performs no verification of the server's certificate.
 This mode disables many of the security benefits of SSL/TLS and should only be used after cautious consideration.
 It is primarily intended as a temporary diagnostic mechanism when attempting to resolve TLS errors.
 Using `none`  in production environments is strongly discouraged.
@@ -448,7 +535,66 @@ being leased to the consumer. Non-positive value passed to this method disables
 connection validation. This check helps detect connections that have become
 stale (half-closed) while kept inactive in the pool."
 
+[id="plugins-{type}s-{plugin}-examples"]
+==== HTTP Filter Examples
 
+===== Capturing Error Responses
+
+This example shows how to capture and process error responses from an API:
+
+```
+filter {
+  http {
+    url => "https://api.example.com/users/%{[user_id]}"
+    verb => "GET"
+    target_body => "[api_response]"
+    target_status_code => "[api_status]"
+    target_headers => "[@metadata][api_headers]"
+    include_body_on_failure => true
+  }
+  
+  # Process based on status code
+  if [api_status] {
+    if [api_status] >= 400 and [api_status] < 500 {
+      mutate {
+        add_tag => [ "client_error" ]
+        add_field => { 
+          "error_type" => "client_error"
+          "error_message" => "%{[api_response][error]}"
+        }
+      }
+    } else if [api_status] >= 500 {
+      mutate {
+        add_tag => [ "server_error" ]
+        add_field => { "error_type" => "server_error" }
+      }
+    }
+  }
+}
+```
+
+===== Handling Connection Errors
+
+When connection errors occur, the status code is set to 0:
+
+```
+filter {
+  http {
+    url => "https://api.example.com/endpoint"
+    target_body => "[response]"
+    target_status_code => "[@metadata][status]"
+  }
+  
+  if [@metadata][status] == 0 {
+    mutate {
+      add_tag => [ "connection_error" ]
+      add_field => { 
+        "alert" => "API connection failed"
+      }
+    }
+  }
+}
+```
 
 [id="plugins-{type}s-{plugin}-obsolete-options"]
 ==== HTTP Filter Obsolete Configuration Options

--- a/lib/logstash/filters/http.rb
+++ b/lib/logstash/filters/http.rb
@@ -33,6 +33,17 @@ class LogStash::Filters::Http < LogStash::Filters::Base
   config :target_body, :validate => :field_reference
   # default [headers] (legacy) or [@metadata][filter][http][response][headers] in ECS mode
   config :target_headers, :validate => :field_reference
+  
+  # New configuration for status code field
+  # default [@metadata][filter][http][response][status_code] in ECS mode or [@metadata][http_status_code] in legacy
+  config :target_status_code, :validate => :field_reference
+  
+  # Configuration to control whether to include response body on failure
+  # Default is true 
+  config :include_body_on_failure, :validate => :boolean, :default => true
+  
+  # Configuration to control whether to include status code always
+  config :include_status_code, :validate => :boolean, :default => true
 
   # Append values to the `tags` field when there has been no
   # successful match or json parsing error
@@ -49,6 +60,10 @@ class LogStash::Filters::Http < LogStash::Filters::Base
     end
 
     @target_headers ||= ecs_select[disabled: '[headers]', v1: '[@metadata][filter][http][response][headers]']
+    
+    # Initialize target_status_code with sensible defaults
+    @target_status_code ||= ecs_select[disabled: '[@metadata][http_status_code]', 
+                                       v1: '[@metadata][filter][http][response][status_code]']
   end
 
   def register
@@ -73,6 +88,9 @@ class LogStash::Filters::Http < LogStash::Filters::Base
 
     @logger.debug? && @logger.debug('processing request', :url => url_for_event, :headers => headers_sprintfed, :query => query_sprintfed)
     client_error = nil
+    code = nil
+    response_headers = nil
+    response_body = nil
 
     begin
       code, response_headers, response_body = request_http(@verb, url_for_event, options)
@@ -85,16 +103,50 @@ class LogStash::Filters::Http < LogStash::Filters::Base
                     :url => url_for_event, :body => body_sprintfed,
                     :client_error => client_error.message)
       @tag_on_request_failure.each { |tag| event.tag(tag) }
+      
+      # Set error information in metadata
+      if @include_status_code && @target_status_code
+        # Set status code as 0 or nil to indicate connection/client error
+        event.set(@target_status_code, 0)
+      end
+      
+      # Optionally set error message in body for client errors
+      if @include_body_on_failure && @target_body
+        error_response = {
+          "error" => "client_error",
+          "message" => client_error.message,
+          "url" => url_for_event
+        }
+        event.set(@target_body, error_response)
+      end
+      
     elsif !code.between?(200, 299)
       @logger.error('error during HTTP request',
                     :url => url_for_event, :code => code,
                     :headers => response_headers,
                     :response => response_body)
       @tag_on_request_failure.each { |tag| event.tag(tag) }
+      
+      # Set status code even for failure responses
+      if @include_status_code && @target_status_code
+        event.set(@target_status_code, code)
+      end
+      
+      # Process response body even for failure status codes
+      if @include_body_on_failure
+        process_response(response_body, response_headers, event, true)
+      end
+      
     else
       @logger.debug? && @logger.debug('success received',
                                       :code => code, :headers => response_headers, :body => response_body)
-      process_response(response_body, response_headers, event)
+      
+      # Set status code for successful responses
+      if @include_status_code && @target_status_code
+        event.set(@target_status_code, code)
+      end
+      
+      process_response(response_body, response_headers, event, false)
       filter_matched(event)
     end
   end # def filter
@@ -132,7 +184,7 @@ EOF
     end
   end
 
-  def process_response(body, headers, event)
+  def process_response(body, headers, event, is_error_response = false)
     event.set(@target_headers, headers)
     return if @verb == 'head' # Since HEAD requests will not contain body, we need to set only header
 
@@ -148,7 +200,12 @@ EOF
         else
           @logger.warn('JSON parsing error', :message => e.message)
         end
-        @tag_on_json_failure.each { |tag| event.tag(tag) }
+        # Only tag JSON failures for successful responses to avoid double tagging
+        if !is_error_response
+          @tag_on_json_failure.each { |tag| event.tag(tag) }
+        end
+        # Still set the raw body if JSON parsing fails
+        event.set(@target_body, body.strip)
       end
     else
       event.set(@target_body, body.strip)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->
- enhancement

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
Added support for capturing HTTP status codes and error response bodies in the HTTP filter plugin. New configuration options `target_status_code`, `include_body_on_failure`, and `include_status_code` enable better error handling and debugging capabilities for failed HTTP requests.


## What does this PR do?
This PR enhances the HTTP filter plugin to capture and expose HTTP status codes and response bodies even for non-2xx responses, significantly improving error handling and debugging capabilities.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.


Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->

### Changes implemented:
1. **Added `target_status_code` configuration**: A configurable field to store HTTP status codes for all responses (successful and failed)
2. **Added `include_body_on_failure` option**: Controls whether to capture response body for failed requests (default: true)
3. **Added `include_status_code` option**: Controls whether to always include the status code (default: true)
4. **Enhanced error handling**: 
   - Status codes are captured for all responses (2xx, 4xx, 5xx)
   - Connection/client errors set status code to 0 for easy identification
   - Response bodies are preserved for error responses when enabled
   - Structured error messages for connection failures

### Technical implementation:
- Modified the `filter` method to capture status codes and response bodies for all scenarios
- Updated `process_response` method to handle error responses without losing data
- Added ECS-compatible default field paths for status codes
- Maintained full backward compatibility with existing configuration


## Why is it important/What is the impact to the user?
### Current limitations:
Previously, the HTTP filter only added failure tags (`_httprequestfailure`) for non-2xx responses without exposing:
- The actual HTTP status code
- The error response body (which often contains valuable error details)

This made debugging API integrations difficult and prevented proper error handling in pipelines.

### User benefits:
1. **Better debugging**: Access to actual error messages from APIs instead of just failure tags
2. **Improved monitoring**: Status codes available for metrics and alerting
3. **Conditional processing**: Ability to handle different error types (4xx vs 5xx) differently
4. **Connection error detection**: Status code 0 clearly identifies network/connection issues
5. **No breaking changes**: Existing pipelines continue working without modification


<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->
### Example use case:
```ruby
filter {
  http {
    url => "https://api.example.com/endpoint"
    target_body => "[api_response]"
    target_status_code => "[api_status]"
    include_body_on_failure => true
  }
  
  # Now users can handle errors properly
  if [api_status] >= 400 and [api_status] < 500 {
    # Handle client errors with actual error message
    mutate { add_field => { "error" => "%{[api_response][message]}" } }
  }
}
```
## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ :white_check_mark: ] My code follows the style guidelines of this project
- [ :white_check_mark: ] I have commented my code, particularly in hard-to-understand areas
- [ :white_check_mark: ] I have made corresponding changes to the documentation
- [ :white_check_mark: ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [ :white_check_mark: ] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

Scenario 1: API Rate Limiting
Given an API that returns 429 status with rate limit information
When the HTTP filter makes a request that triggers rate limiting
Then the status code (429) and response body (containing retry-after info) should be accessible

Scenario 2: API Validation Errors
Given an API that returns 400 with validation error details
When the HTTP filter sends invalid data
Then the validation errors in the response body should be accessible for logging/processing

Scenario 3: Service Unavailable
Given an API that is temporarily down (503)
When the HTTP filter attempts to connect
Then the 503 status should be captured for monitoring/alerting

Scenario 4: Network Issues
Given a network timeout or connection refused scenario
When the HTTP filter cannot establish connection
Then status code should be 0 with descriptive error message

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
